### PR TITLE
Move follow-ups to FOLLOWUPS.md and link Jira tickets

### DIFF
--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1,0 +1,16 @@
+## Follow-ups
+
+Tracked work for Get Up Ledger. Tickets live in [Jira (KAN)](https://emmapuls.atlassian.net/browse/KAN).
+
+### Planned (long term)
+- [KAN-6](https://emmapuls.atlassian.net/browse/KAN-6) — Add category & tag handling
+- [KAN-7](https://emmapuls.atlassian.net/browse/KAN-7) — Add localisation for different languages
+  *If you have a preferred language please [open a GitHub issue](https://github.com/EmmaPuls/Get-Up-Ledger/issues) and I'll focus on those first when I start this*
+- [KAN-8](https://emmapuls.atlassian.net/browse/KAN-8) — Allow selecting a date range to download data
+
+### Known bugs
+- [KAN-9](https://emmapuls.atlassian.net/browse/KAN-9) — Some accounts do not appear to have the emoji in the correct column
+
+### In-code TODOs
+- [KAN-4](https://emmapuls.atlassian.net/browse/KAN-4) — Let users define the number format (`Get Up App/Models/Balance.swift`)
+- [KAN-5](https://emmapuls.atlassian.net/browse/KAN-5) — Add `Transaction.relationships` field (`Get Up App/Models/Transaction.swift`)

--- a/Get Up App/Models/Balance.swift
+++ b/Get Up App/Models/Balance.swift
@@ -25,7 +25,7 @@ struct Balance: Codable {
         try container.encode(valueInBaseUnits, forKey: .valueInBaseUnits)
     }
     
-    // TODO: Let users define the number format
+    // TODO: Let users define the number format — https://emmapuls.atlassian.net/browse/KAN-4
     func toString() -> String {
         // Format the valueInBaseUnits to a string format for dollars (including dollars and decimal points, assume the last two digits are the decimal points
         let dollars = valueInBaseUnits / 100

--- a/Get Up App/Models/Transaction.swift
+++ b/Get Up App/Models/Transaction.swift
@@ -5,7 +5,7 @@
 //  Created by Emma Puls on 23/2/2025.
 //
 
-// TODO: Add Tranaction relationships field
+// TODO: Add Transaction relationships field — https://emmapuls.atlassian.net/browse/KAN-5
 final class Transaction: Codable, Identifiable, Equatable {
     
     let id: String

--- a/README.md
+++ b/README.md
@@ -31,11 +31,5 @@ If you want to download the data for a particular account click the "Download Al
 ### Requests for changes
 - Please open an [Issue on Github](https://github.com/EmmaPuls/Get-Up-Ledger/issues) to request new features or report bugs
 
-### My Todo list (long term)
-- Add category & tag handling
-- Add localisation for different languages 
-  *If you have a preferred language please create an issue and I'll focus on those first when I start this*
-- Allow selecting a date range to download data
-
-### Known bugs
-- Some accounts do not appear to have the emoji in the correct column
+### Follow-ups & known bugs
+See [FOLLOWUPS.md](FOLLOWUPS.md) for the long-term roadmap, known bugs, and in-code TODOs (all tracked in [Jira](https://emmapuls.atlassian.net/browse/KAN)).


### PR DESCRIPTION
## Summary
- Split the long-term roadmap and known bugs out of `README.md` into a new `FOLLOWUPS.md`.
- Add Jira ticket URLs to the two in-code TODOs (`Balance.swift` → KAN-4, `Transaction.swift` → KAN-5).
- `FOLLOWUPS.md` indexes all six tickets (KAN-4…KAN-9) so each follow-up has a single canonical reference.
- Fixes the `Tranaction` typo in `Transaction.swift` while updating the comment.

## Test plan
- [x] `README.md` renders on GitHub with the new "Follow-ups & known bugs" section linking to `FOLLOWUPS.md`.
- [x] `FOLLOWUPS.md` renders with all six ticket links resolving to https://emmapuls.atlassian.net/browse/KAN-*.
- [x] Project still builds (no source behaviour changed — comment-only edits in Swift files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)