### PR TITLE
Trim whitespace after emoji prefix and add 💳 fallback for transactional accounts

### DIFF
--- a/Get Up App.xcodeproj/project.pbxproj
+++ b/Get Up App.xcodeproj/project.pbxproj
@@ -473,7 +473,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Get Up App.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Get Up App";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Get Up Ledger.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Get Up Ledger";
 			};
 			name = Debug;
 		};
@@ -491,7 +491,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Get Up App.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Get Up App";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Get Up Ledger.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Get Up Ledger";
 			};
 			name = Release;
 		};

--- a/Get Up App/Models/Account.swift
+++ b/Get Up App/Models/Account.swift
@@ -72,7 +72,12 @@ struct AccountAttributes: Codable {
         // If the first character in displayName is an emoji, remove it and add it to the emoji property
         if let firstCharacter = displayName.first, firstCharacter.isEmoji {
             emoji = String(firstCharacter)
-            modifiedDisplayName = String(displayName.dropFirst())
+            modifiedDisplayName = displayName.dropFirst().trimmingCharacters(in: .whitespaces)
+        } else if accountType == "TRANSACTIONAL" {
+            // GUA-9: transactional accounts never carry a user-defined emoji, so fall back to a
+            // credit-card glyph to keep the emoji column aligned with saver rows.
+            emoji = "💳"
+            modifiedDisplayName = displayName
         } else {
             emoji = nil
             modifiedDisplayName = displayName

--- a/Get Up AppTests/Get_Up_AppTests.swift
+++ b/Get Up AppTests/Get_Up_AppTests.swift
@@ -5,13 +5,72 @@
 //  Created by Emma Puls on 22/2/2025.
 //
 
+import Foundation
 import Testing
-@testable import Get_Up_App
+@testable import Get_Up_Ledger
 
 struct Get_Up_AppTests {
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    private func decodeAttributes(displayName: String, accountType: String) throws -> AccountAttributes {
+        let json = """
+        {
+          "displayName": "\(displayName)",
+          "accountType": "\(accountType)",
+          "ownershipType": "INDIVIDUAL",
+          "balance": {
+            "currencyCode": "AUD",
+            "value": "0.00",
+            "valueInBaseUnits": 0
+          },
+          "createdAt": "2025-01-01T00:00:00+10:00"
+        }
+        """
+        return try JSONDecoder().decode(AccountAttributes.self, from: Data(json.utf8))
     }
 
+    // MARK: - GUA-9: emoji fallback for transactional accounts
+
+    @Test func transactionalAccountWithoutEmojiFallsBackToCreditCard() throws {
+        let attrs = try decodeAttributes(displayName: "Spending", accountType: "TRANSACTIONAL")
+
+        #expect(attrs.emoji == "💳")
+        #expect(attrs.modifiedDisplayName == "Spending")
+    }
+
+    @Test func transactionalAccountWithUserEmojiKeepsUserEmoji() throws {
+        let attrs = try decodeAttributes(displayName: "🍕 Pizza Fund", accountType: "TRANSACTIONAL")
+
+        #expect(attrs.emoji == "🍕")
+        #expect(attrs.modifiedDisplayName == "Pizza Fund")
+    }
+
+    @Test func saverAccountWithoutEmojiHasNilEmoji() throws {
+        // Demonstrates current behaviour for non-transactional accounts: no fallback is applied,
+        // so the emoji column will still be empty for a saver that hasn't been given an emoji.
+        let attrs = try decodeAttributes(displayName: "Holiday", accountType: "SAVER")
+
+        #expect(attrs.emoji == nil)
+        #expect(attrs.modifiedDisplayName == "Holiday")
+    }
+
+    @Test func saverAccountWithUserEmojiKeepsUserEmoji() throws {
+        let attrs = try decodeAttributes(displayName: "💰 Savings", accountType: "SAVER")
+
+        #expect(attrs.emoji == "💰")
+        #expect(attrs.modifiedDisplayName == "Savings")
+    }
+
+    @Test func saverAccountWithEmojiAndTrailingWhitespaceTrimsBothEnds() throws {
+        let attrs = try decodeAttributes(displayName: "🐶 Dog ", accountType: "SAVER")
+
+        #expect(attrs.emoji == "🐶")
+        #expect(attrs.modifiedDisplayName == "Dog")
+    }
+
+    @Test func saverAccountWithEmojiAndNoSpaceLeavesNameIntact() throws {
+        let attrs = try decodeAttributes(displayName: "🐶Dog", accountType: "SAVER")
+
+        #expect(attrs.emoji == "🐶")
+        #expect(attrs.modifiedDisplayName == "Dog")
+    }
 }


### PR DESCRIPTION
## Summary
- Trim leading whitespace from `displayName` after pulling the emoji off, so `"🐶 Dog"` → emoji `"🐶"`, name `"Dog"` (was `" Dog"`).
- Fall back to 💳 as the emoji for `TRANSACTIONAL` accounts that don't carry a user-defined emoji, keeping the emoji column aligned with saver rows (GUA-9).
- Fix the unit-test target's `TEST_HOST` to point at the renamed `Get Up Ledger.app` and switch `@testable import` to `Get_Up_Ledger` so the new tests can actually run.

## Test plan
- [x] `⇧⌘K` clean build folder, then run the `Get Up AppTests` scheme — all 6 `AccountAttributes` cases pass.
- [x] Launch the app, confirm transactional accounts without a user emoji now render with 💳.
- [x] Confirm a saver named `"🐶 Dog"` displays as `Dog` (no leading space) with the dog emoji in its own column.
- [x] Confirm a saver with no emoji prefix still renders with an empty emoji column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)