### PR TITLE
Gua 34 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Cargo.toml
 .DS_Store
 UserInterfaceState.xcuserstate
 /AppData
+/build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,6 +128,59 @@ Tags are `v`-prefixed (`v1.2.0`); the branch and `MARKETING_VERSION` are not
 > a smoke test (verifies the pinned knope version installs and `knope.toml`
 > parses). Automating steps 4–5 is tracked for a later ticket.
 
+## Building and signing the archive
+
+Release builds are archived and signed **locally in Xcode** on a Mac. There is
+no CI archive step — the `Release` workflow only smoke-tests knope. Building on
+your own machine guarantees the archive is signed with the team's certificate
+and provisioning profile, which the App Store upload requires.
+
+### 1. Build the archive
+
+1. Open `Get Up App.xcodeproj` in Xcode.
+2. Select the **Get Up App** scheme and set the destination to **Any Mac
+   (Apple Silicon, Intel)**.
+3. Make sure the version is current — `MARKETING_VERSION` in
+   [`Version.xcconfig`](Version.xcconfig) is set by `knope release` (see above),
+   and the build number lives in the Xcode project.
+4. **Product → Archive.**
+
+Signing is **Automatic** with the team's `DEVELOPMENT_TEAM` set in the project,
+so Xcode picks the matching certificate and profile. Do not build with signing
+disabled — an unsigned archive has empty `Team` / `SigningIdentity` fields and
+the Organizer rejects it (see troubleshooting below).
+
+### 2. Distribute
+
+1. The Organizer opens on the new archive (or **Window → Organizer**).
+2. **Distribute App** → choose the destination (App Store Connect or Developer
+   ID) → **Automatic** signing → upload or export.
+
+### Troubleshooting: "No Team Found in Archive"
+
+```
+No Team Found in Archive
+Use the Signing & Capabilities editor to assign a team to the targets and
+build a new archive.
+```
+
+This means the archive was built **unsigned** — its `Info.plist`
+`ApplicationProperties` has empty `Team` and `SigningIdentity`. Rebuild via
+**Product → Archive** with Automatic signing (the normal path above produces a
+signed archive).
+
+To unblock an already-built archive without rebuilding, inject the team ID into
+its `Info.plist` (replace `<TEAM_ID>` with your Apple Developer team ID and the
+path with your archive):
+
+```sh
+plutil -replace ApplicationProperties.Team -string <TEAM_ID> \
+  "$HOME/Library/Developer/Xcode/Archives/<DATE>/<ARCHIVE>.xcarchive/Info.plist"
+```
+
+Reopen the Organizer and distribute — Automatic signing re-signs at export, so
+the empty `SigningIdentity` is filled in then.
+
 ## CI checks
 
 - **Changeset exists** — every PR against `main` must add a file under

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,6 +181,31 @@ plutil -replace ApplicationProperties.Team -string <TEAM_ID> \
 Reopen the Organizer and distribute — Automatic signing re-signs at export, so
 the empty `SigningIdentity` is filled in then.
 
+### Building a DMG with the helper script
+
+[`scripts/build-dmg.sh`](scripts/build-dmg.sh) automates archive → validate →
+DMG for distributing the app as a disk image (outside the App Store). It:
+
+1. Archives the **Get Up App** scheme (`Release`, signed with `DEVELOPMENT_TEAM`).
+2. Opens the archive in the Organizer and **waits** for you to validate it
+   (Distribute App → choose method → Validate), then prompts for confirmation.
+3. Packages the archived `.app` into a `.dmg` with
+   [`create-dmg`](https://github.com/create-dmg/create-dmg).
+
+```sh
+brew install create-dmg   # one-time
+./scripts/build-dmg.sh
+```
+
+Output lands in `build/` (gitignored): `Get Up Ledger-<version>.xcarchive` and
+`Get Up Ledger-<version>.dmg`, where `<version>` is `MARKETING_VERSION` from
+[`Version.xcconfig`](Version.xcconfig). Override `CONFIG`, `DEVELOPMENT_TEAM`,
+or `BUILD_DIR` via environment variables.
+
+The **DMG is not code-signed** (no Developer ID certificate); the `.app` inside
+keeps its archive signature. This artifact is for direct distribution, separate
+from the App Store upload path above.
+
 ## CI checks
 
 - **Changeset exists** — every PR against `main` must add a file under

--- a/Get Up App.xcodeproj/project.pbxproj
+++ b/Get Up App.xcodeproj/project.pbxproj
@@ -24,11 +24,11 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		3FAA00012D699ED70056B2F6 /* Version.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Version.xcconfig; sourceTree = "<group>"; };
 		3F94C0E22D699ED60056B2F6 /* Get Up Ledger.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Get Up Ledger.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3F94C0F52D699ED70056B2F6 /* Get Up AppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Get Up AppTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3F94C0FF2D699ED70056B2F6 /* Get Up AppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Get Up AppUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
-		/* End PBXFileReference section */
+		3FAA00012D699ED70056B2F6 /* Version.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Version.xcconfig; sourceTree = "<group>"; };
+/* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		3F94C0E42D699ED60056B2F6 /* Get Up App */ = {

--- a/scripts/build-dmg.sh
+++ b/scripts/build-dmg.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#
+# build-dmg.sh — archive the app, pause for manual validation, then build an
+# (unsigned) DMG with create-dmg.
+#
+# Flow:
+#   1. Archive "Get Up App" (Release, signed with the development team).
+#   2. Open the archive in Xcode Organizer and wait for you to Validate it.
+#   3. Once you confirm, package the archived .app into a .dmg via create-dmg.
+#
+# The DMG itself is NOT code-signed (no Developer ID cert). The .app inside
+# keeps whatever signature the archive produced.
+#
+# Overridable via env: CONFIG, DEVELOPMENT_TEAM, BUILD_DIR.
+# Requires: Xcode command line tools, create-dmg (brew install create-dmg).
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+PROJECT="Get Up App.xcodeproj"
+SCHEME="Get Up App"
+APP_NAME="Get Up Ledger"
+CONFIG="${CONFIG:-Release}"
+TEAM="${DEVELOPMENT_TEAM:-4JL9AZ65QR}"
+BUILD_DIR="${BUILD_DIR:-$ROOT/build}"
+
+command -v create-dmg >/dev/null 2>&1 || {
+  echo "error: create-dmg not found. Install with: brew install create-dmg" >&2
+  exit 1
+}
+
+VERSION="$(grep -E '^MARKETING_VERSION' Version.xcconfig | sed 's/.*=[[:space:]]*//')"
+[ -n "$VERSION" ] || { echo "error: could not read MARKETING_VERSION from Version.xcconfig" >&2; exit 1; }
+
+ARCHIVE="$BUILD_DIR/${APP_NAME}-${VERSION}.xcarchive"
+DMG="$BUILD_DIR/${APP_NAME}-${VERSION}.dmg"
+
+mkdir -p "$BUILD_DIR"
+
+# 1. Archive ------------------------------------------------------------------
+echo "==> Archiving ${APP_NAME} ${VERSION} (${CONFIG}, team ${TEAM})"
+rm -rf "$ARCHIVE"
+xcodebuild \
+  -project "$PROJECT" \
+  -scheme "$SCHEME" \
+  -configuration "$CONFIG" \
+  -destination 'generic/platform=macOS' \
+  -archivePath "$ARCHIVE" \
+  DEVELOPMENT_TEAM="$TEAM" \
+  archive
+
+# 2. Validate (manual) --------------------------------------------------------
+echo
+echo "==> Archive created:"
+echo "    $ARCHIVE"
+echo "    file://$ARCHIVE"
+echo
+echo "Opening the archive in Xcode Organizer..."
+open "$ARCHIVE" || true
+echo
+echo "Validate it now: in Organizer select the archive, click"
+echo "\"Distribute App\" → choose your method → \"Validate\"."
+echo
+read -r -p "Type 'validated' once validation has passed (anything else aborts): " CONFIRM
+if [ "$CONFIRM" != "validated" ]; then
+  echo "Aborted — DMG not built." >&2
+  exit 1
+fi
+
+# 3. Build the DMG ------------------------------------------------------------
+APP="$ARCHIVE/Products/Applications/${APP_NAME}.app"
+[ -d "$APP" ] || { echo "error: app not found in archive: $APP" >&2; exit 1; }
+
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
+cp -R "$APP" "$STAGE/"
+
+echo
+echo "==> Building DMG"
+rm -f "$DMG"
+
+# create-dmg can exit non-zero on a benign Finder/AppleScript hiccup, so don't
+# let set -e abort — verify the DMG exists afterwards instead.
+set +e
+create-dmg \
+  --volname "${APP_NAME} ${VERSION}" \
+  --window-pos 200 120 \
+  --window-size 660 400 \
+  --icon-size 100 \
+  --icon "${APP_NAME}.app" 165 200 \
+  --app-drop-link 495 200 \
+  --no-internet-enable \
+  "$DMG" "$STAGE"
+RC=$?
+set -e
+
+if [ ! -f "$DMG" ]; then
+  echo "error: create-dmg failed (exit $RC) — no DMG produced." >&2
+  exit "$RC"
+fi
+
+echo
+echo "==> Done:"
+echo "    $DMG"
+echo "    file://$DMG"


### PR DESCRIPTION
This pull request adds detailed documentation and a new script to streamline building and distributing release archives for the macOS app. The main focus is on guiding developers through the local build, signing, and DMG packaging process, ensuring compliance with App Store requirements and simplifying direct distribution.

**Documentation improvements:**

* Expanded `CONTRIBUTING.md` to include comprehensive instructions for building, signing, and distributing release archives locally in Xcode, troubleshooting unsigned archives, and using the new DMG helper script for non–App Store distribution.

**Build tooling enhancements:**

* Added a new script `scripts/build-dmg.sh` that automates archiving the app, prompts for manual validation in Xcode Organizer, and packages the signed `.app` into an unsigned DMG using `create-dmg`. The script supports environment variable overrides and ensures the correct versioning and team signing.

**Project configuration:**

* Minor update in `Get Up App.xcodeproj/project.pbxproj` to maintain the correct reference to `Version.xcconfig`.